### PR TITLE
AppSync: Intercept Events

### DIFF
--- a/moto/appsync/responses.py
+++ b/moto/appsync/responses.py
@@ -1,8 +1,11 @@
 """Handles incoming appsync requests, invokes methods, returns responses."""
 
 import json
+from typing import Any
 from urllib.parse import unquote
+from uuid import uuid4
 
+from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
 
 from .models import AppSyncBackend, appsync_backends
@@ -13,6 +16,16 @@ class AppSyncResponse(BaseResponse):
 
     def __init__(self) -> None:
         super().__init__(service_name="appsync")
+
+    @staticmethod
+    def dns_event_response(request: Any, url: str, headers: Any) -> TYPE_RESPONSE:  # type: ignore[misc]
+        data = json.loads(request.data.decode("utf-8"))
+
+        response: dict[str, list[Any]] = {"failed": [], "successful": []}
+        for idx in range(len(data.get("events", []))):
+            response["successful"].append({"identifier": str(uuid4()), "index": idx})
+
+        return 200, {}, json.dumps(response).encode("utf-8")
 
     @property
     def appsync_backend(self) -> AppSyncBackend:

--- a/moto/appsync/urls.py
+++ b/moto/appsync/urls.py
@@ -4,6 +4,7 @@ from .responses import AppSyncResponse
 
 url_bases = [
     r"https?://appsync\.(.+)\.amazonaws\.com",
+    r"https?://([a-zA-Z0-9\-_]+)\.appsync-api\.(.+)\.amazonaws\.com",
 ]
 
 
@@ -24,4 +25,5 @@ url_paths = {
     "{0}/v2/apis/(?P<apiId>[^/]+)$": AppSyncResponse.dispatch,
     "{0}/v2/apis/(?P<apiId>[^/]+)/channelNamespaces$": AppSyncResponse.dispatch,
     "{0}/v2/apis/(?P<apiId>[^/]+)/channelNamespaces/(?P<name>[^/]+)$": AppSyncResponse.dispatch,
+    "{0}/event$": AppSyncResponse.dns_event_response,
 }

--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -17,6 +17,12 @@ backend_url_patterns = [
     ),
     ("appmesh", re.compile("https?://appmesh\\.(.+)\\.amazonaws\\.com")),
     ("appsync", re.compile("https?://appsync\\.(.+)\\.amazonaws\\.com")),
+    (
+        "appsync",
+        re.compile(
+            "https?://([a-zA-Z0-9\\-_]+)\\.appsync-api\\.(.+)\\.amazonaws\\.com"
+        ),
+    ),
     ("athena", re.compile("https?://athena\\.(.+)\\.amazonaws\\.com")),
     ("autoscaling", re.compile("https?://autoscaling\\.(.+)\\.amazonaws\\.com")),
     ("awslambda", re.compile("https?://lambda\\.(.+)\\.amazonaws\\.com")),


### PR DESCRIPTION
Hi @ThiagoDiasV! In response to your [AppSync PR in Moto](https://github.com/getmoto/moto/pull/8898) - this change removes the need to manually intercept the request.

The part that was missing from your implementation was the additional URL's in `moto/backend_index.py`, a list of all URLs across all services. 

As an FYI: this list is used so we don't have to load all the individual services on startup just to look at the URLs, which would incur a significance performance penalty. If you want to change the URL, you can do so in the service backend - and then run `scripts/update_backend_index.py` to automatically update the list in `moto/backend_index.py`.

Another change I made is that the end-to-end test is now disabled in ServerMode. Moto runs in a completely separate process there, and we can change the endpoint for boto3-calls to make sure they are redirected to the server - but we don't intercept `request.post(..)` calls.